### PR TITLE
Update edit profile authorization

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
   end
 
   def edit
-    @user = User.find(params[:id])
+    @user = current_user
   end
 
   def update

--- a/spec/features/users/user_can_edit_profile_spec.rb
+++ b/spec/features/users/user_can_edit_profile_spec.rb
@@ -18,4 +18,19 @@ describe "a logged in user" do
     expect(page).to have_content("new@com.com")
     expect(page).to_not have_content("email@email.com")
   end
+
+  it "cannot edit the profile of another user" do
+    user = User.create(email: "email@email.com", first_name: "User", last_name: "Name", about_me: "Logged in", phone_number: "853-343-2343", password: "123")
+    user.roles.create(title: "traveler")
+    host = User.create(email: "host@email.com", first_name: "Castle", last_name: "Pines", about_me: "Not", phone_number: "853-343-9943", password: "123")
+    host.roles.create(title: "host")
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit "/users/#{host.id}/edit"
+
+    expect(page).to_not have_content("host@email.com")
+    expect(page).to_not have_content("Castle")
+    expect(page).to_not have_content("Pines")
+    expect(page).to_not have_content("Not")
+  end
 end


### PR DESCRIPTION
Adds feature test and update for a user cannot edit the profile of a user
strategy: use `current_user` instead of finding the user from params[:id]

RSpec: 102 examples, 0 failures, 1 pending