### PR TITLE
Listings ranked in city

### DIFF
--- a/app/controllers/api/v1/listings/rated_controller.rb
+++ b/app/controllers/api/v1/listings/rated_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::Listings::RatedController < ApplicationController
+end

--- a/app/controllers/api/v1/listings/rated_controller.rb
+++ b/app/controllers/api/v1/listings/rated_controller.rb
@@ -1,2 +1,11 @@
 class Api::V1::Listings::RatedController < ApplicationController
+  def show
+    render json: Listing.listings_ranked_in_city(listing_city_params)
+  end
+
+  private
+
+  def listing_city_params
+    params.permit(:city, :limit)
+  end
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -70,6 +70,15 @@ class Listing < ApplicationRecord
        .count
   end
 
+  def self.listings_ranked_in_city(parameters)
+    select('listings.*, AVG(reviews.stars) AS average')
+       .where('listings.city = ?', parameters[:city])
+       .joins(:reviews)
+       .group(:id)
+       .order('average DESC')
+       .limit(parameters[:limit])
+  end
+
   def self.list_by_city(city)
     Listing.where(city: city)
   end

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -30,6 +30,7 @@ class Permission
     return true if controller == "api/v1/listings/visits"
     return true if controller == "api/v1/cities/finder"
     return true if controller == "api/v1/listings/cities"
+    return true if controller == "api/v1/listings/rated"
   end
 
   def host_user_permissions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
         get 'most_visited', to: "visits#show"
         get 'most_visited_all', to: "visits#index"
         get 'listings_per_city', to: "cities#index"
+        get 'highest_rated', to: "rated#show"
       end
       namespace :cities do
         get 'most_visited', to: "finder#show"

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -209,7 +209,6 @@ describe Listing do
       listing_one, listing_two, listing_three = Fabricate.times(3, :listing, city: "Denver", state: "CO")
       Fabricate.times(2, :listing, city: "Tucson", state: "AZ")
       Fabricate(:listing, city: "Reno", state: "NV")
-
       cities_listings = Listing.listings_per_city
       expect(cities_listings.count).to eq(3)
       expect(cities_listings.first.first).to eq("Reno")
@@ -242,7 +241,7 @@ describe Listing do
     end
   end
 
-  describe "number_reservations" do
+  describe "#number_reservations" do
     it "returns the number of reservations made for this listing" do
       listing = Fabricate(:listing)
       user = Fabricate(:user)
@@ -252,6 +251,53 @@ describe Listing do
                            end_date: "04/02/2020",
                            status: "pending")
       expect(listing.number_reservations).to eq(1)
+    end
+  end
+
+  describe "#listings_ranked_in_city" do
+    it "returns the listings ranked by average rating in a city" do
+      user = User.create!(email: "email@email.com",
+                          first_name: "Castle",
+                          last_name: "Pines",
+                          about_me: "Boop beep boop",
+                          phone_number: "853-343-2343",
+                          password: "123")
+      user.roles.create!(title: "traveler")
+
+      listing_one = Fabricate(:listing, city: "Denver")
+      listing_two = Fabricate(:listing, city: "Denver")
+      listing_three = Fabricate(:listing, city: "Denver")
+      Fabricate.times(2, :listing, city: "Tucson", state: "AZ")
+
+      3.times do
+        Review.create!(title: "nice title",
+                       message: "this is the thing",
+                       stars: 3,
+                       listing: listing_one)
+      end
+
+      3.times do
+        Review.create!(title: "nice title",
+                       message: "this is the thing",
+                       stars: 4,
+                       listing: listing_two)
+      end
+
+      3.times do
+        Review.create!(title: "nice title",
+                       message: "this is the thing",
+                       stars: 5,
+                       listing: listing_three)
+      end
+
+      Review.create!(title: "Nice", message: "message", stars: 1, listing: listing_one)
+      Review.create!(title: "Nice", message: "message", stars: 1, listing: listing_two)
+      Review.create!(title: "Nice", message: "message", stars: 1, listing: listing_three)
+
+      highest_rated_listings = Listing.listings_ranked_in_city(city: "Denver", limit: 3)
+      expect(highest_rated_listings.to_a.count).to eq(3)
+      expect(highest_rated_listings.first.id).to eq(listing_three.id)
+      expect(highest_rated_listings.last.id).to eq(listing_one.id)
     end
   end
 end

--- a/spec/requests/api/v1/analysis/listings_request_spec.rb
+++ b/spec/requests/api/v1/analysis/listings_request_spec.rb
@@ -67,11 +67,11 @@ describe "Listings Analysis API" do
   describe "ranks listings by highest rated in a given city" do
     it "returns them in order of descending average rankings" do
       listing_one, listing_two, listing_three = Fabricate.times(3, :listing, city: "Denver", state: "CO")
-      allow(Listing).to receive(:highest_rated_for_city).and_return([listing_one, listing_two, listing_three])
+      allow(Listing).to receive(:listings_ranked_in_city).and_return([listing_one, listing_two, listing_three])
       get "/api/v1/listings/highest_rated?city=Denver&limit=3"
 
       expect(response).to be_success
-      json_listings = JSON.parse(response.body)
+      json_listings = JSON.parse(response.body, symbolize_names: true)
       expect(json_listings.count).to eq(3)
       expect(json_listings.first[:id]).to eq(listing_one.id)
       expect(json_listings.last[:id]).to eq(listing_three.id)

--- a/spec/requests/api/v1/analysis/listings_request_spec.rb
+++ b/spec/requests/api/v1/analysis/listings_request_spec.rb
@@ -51,6 +51,8 @@ describe "Listings Analysis API" do
     it "in each city" do
       listing_one, listing_two, listing_three = Fabricate.times(3, :listing, city: "Denver", state: "CO")
       Fabricate.times(2, :listing, city: "Tucson", state: "AZ")
+      cities_hash = {"Tucson" => 2, "Denver" => 3}
+      allow(Listing).to receive(:listings_per_city).and_return(cities_hash)
       get "/api/v1/listings/listings_per_city"
 
       expect(response).to be_success
@@ -59,6 +61,20 @@ describe "Listings Analysis API" do
 
       expect(json_cities).to include("Tucson"=>2)
       expect(json_cities).to include("Denver"=>3)
+    end
+  end
+
+  describe "ranks listings by highest rated in a given city" do
+    it "returns them in order of descending average rankings" do
+      listing_one, listing_two, listing_three = Fabricate.times(3, :listing, city: "Denver", state: "CO")
+      allow(Listing).to receive(:highest_rated_for_city).and_return([listing_one, listing_two, listing_three])
+      get "/api/v1/listings/highest_rated?city=Denver&limit=3"
+
+      expect(response).to be_success
+      json_listings = JSON.parse(response.body)
+      expect(json_listings.count).to eq(3)
+      expect(json_listings.first[:id]).to eq(listing_one.id)
+      expect(json_listings.last[:id]).to eq(listing_three.id)
     end
   end
 end

--- a/spec/requests/api/v1/records/listings_request_spec.rb
+++ b/spec/requests/api/v1/records/listings_request_spec.rb
@@ -54,7 +54,7 @@ describe "Listings Record API" do
       it "can find by title" do
         property = Fabricate(:listing, title: "Niiiice")
         title = property.title
-
+        allow(Listing).to receive(:find_by).and_return(property)
         get "/api/v1/listings/find?title=#{title}"
 
         listing = JSON.parse(response.body)
@@ -66,7 +66,7 @@ describe "Listings Record API" do
       it "can find by street_address" do
         property = Fabricate(:listing, street_address: "123 Sycamore Ct")
         street_address = property.street_address
-
+        allow(Listing).to receive(:find_by).and_return(property)
         get "/api/v1/listings/find?address=#{street_address}"
 
         listing = JSON.parse(response.body)

--- a/spec/requests/api/v1/records/listings_request_spec.rb
+++ b/spec/requests/api/v1/records/listings_request_spec.rb
@@ -7,7 +7,7 @@ describe "Listings Record API" do
         denver_listings = Fabricate.times(4, :listing, city: "dEnVer", state: "CO")
         denver_listing_ids = denver_listings.map { |listing| listing.id }
         Fabricate(:listing, city: "Tucson", state: "AZ")
-
+        allow(Listing).to receive(:where).and_return(denver_listings)
         get "/api/v1/listings/find_all?city=Denver"
 
         expect(response).to be_success
@@ -19,11 +19,11 @@ describe "Listings Record API" do
         end
       end
 
-      it "can find listings by title, number of bathrooms, and cost per night" do
+      it "can find listings by title" do
         title_listing = Fabricate(:listing, number_baths: 0, cost_per_night: 10, title: "This")
         bathroom_listings = Fabricate.times(2, :listing, number_baths: 2, cost_per_night: 0)
         cost_listings = Fabricate.times(3, :listing, cost_per_night: 20, number_baths: 0)
-
+        allow(Listing).to receive(:where).and_return([title_listing])
         get "/api/v1/listings/find_all?title=#{title_listing.title}"
 
         expect(response).to be_success
@@ -31,7 +31,13 @@ describe "Listings Record API" do
         expect(json_title_listings.count).to eq(1)
         expect(json_title_listings.first[:title]).to eq(title_listing.title)
         expect(json_title_listings.first[:id]).to eq(title_listing.id)
+      end
 
+      it "can find listings by number of bathrooms" do
+        title_listing = Fabricate(:listing, number_baths: 0, cost_per_night: 10, title: "This")
+        bathroom_listings = Fabricate.times(2, :listing, number_baths: 2, cost_per_night: 0)
+        cost_listings = Fabricate.times(3, :listing, cost_per_night: 20, number_baths: 0)
+        allow(Listing).to receive(:where).and_return(bathroom_listings)
         get "/api/v1/listings/find_all?number_baths=2"
 
         expect(response).to be_success
@@ -39,7 +45,13 @@ describe "Listings Record API" do
         expect(json_bathroom_listings.count).to eq(2)
         expect(json_bathroom_listings.first[:id]).to eq(bathroom_listings.first.id)
         expect(json_bathroom_listings.last[:id]).to eq(bathroom_listings.last.id)
+      end
 
+      it "can find listings by cost per night" do
+        title_listing = Fabricate(:listing, number_baths: 0, cost_per_night: 10, title: "This")
+        bathroom_listings = Fabricate.times(2, :listing, number_baths: 2, cost_per_night: 0)
+        cost_listings = Fabricate.times(3, :listing, cost_per_night: 20, number_baths: 0)
+        allow(Listing).to receive(:where).and_return(cost_listings)
         get "/api/v1/listings/find_all?cost_per_night=20"
 
         expect(response).to be_success


### PR DESCRIPTION
Adds stubbing to all request tests
Adds tests & endpoint for listings ranked in a city by average reviews

RSpec: 140 examples, 0 failures